### PR TITLE
Feature/update table columns and add google directions

### DIFF
--- a/app/components/LocationTable/index.js
+++ b/app/components/LocationTable/index.js
@@ -22,11 +22,47 @@ function LocationTable() {
         title="Food Banks"
         columns={[
           { title: 'Name', field: 'name' },
+          { title: 'Type', field: 'type', defaultSort: 'desc' },
+          {
+            title: 'Accepts SNAP',
+            field: 'snap',
+            render: row =>
+              row.snap === true ? (
+                <i className="material-icons">check_box</i>
+              ) : (
+                <i className="material-icons">check_box_outline_blank</i>
+              ),
+          },
+          {
+            title: 'Accepts WIC',
+            field: 'wic',
+            render: row =>
+              row.wic === true ? (
+                <i className="material-icons">check_box</i>
+              ) : (
+                <i className="material-icons">check_box_outline_blank</i>
+              ),
+          },
           { title: 'Opening Time', field: 'open_time1' },
           { title: 'Closing Time', field: 'close_time1' },
+          { title: 'Address', field: 'address' },
         ]}
         data={foodSiteInfo}
         onRowClick={(event, rowData) => setRedirectTo(rowData.id)}
+        actions={[
+          {
+            icon: 'directions',
+            tooltip: 'Get google directions',
+            onClick: (event, rowData) =>
+              window.open(
+                `https://www.google.com/maps/dir/?api=1&destination=${
+                  rowData.longitude
+                }%2C${rowData.latitude}`,
+                '_blank',
+                'noopener',
+              ),
+          },
+        ]}
       />
     </div>
   );


### PR DESCRIPTION
updates the table props to include requested items like address, place type, wic and snap. action button was added back in and can now navigate to google directions for the site. snap and wic render a checkbox full or empty based on true false. table starts default sorted by location type, partly so that an arrow will appear in the column making it more obvious you can sort columns with header clicks. directions button currently has a tooltip saying what it does, it looks like to add actual text below we have to override the action column manually, which is possible but a fair bit of work because we will have to replicate all of it (icon spacing, tooltips, onclick functionality, etc. there is no overriding just part of it . . . 