### PR TITLE
Handle hover over geoJSON features

### DIFF
--- a/app/components/Map/index.js
+++ b/app/components/Map/index.js
@@ -70,12 +70,7 @@ class Map extends React.PureComponent {
             geometry: {
               type: 'Point',
               // GeoJSON takes lat/lon in reverse order
-              // Even more confusing: at least half of the lat/lon values provided are reversed??
-              // Not sure how this wasn't a problem with previous config
-              coordinates:
-                longitude < latitude
-                  ? [longitude, latitude]
-                  : [latitude, longitude],
+              coordinates: [longitude, latitude],
             },
             properties: site,
           });

--- a/app/components/Map/index.js
+++ b/app/components/Map/index.js
@@ -85,7 +85,10 @@ class Map extends React.PureComponent {
     const features = event.features
       ? event.features.filter(feature => feature.layer.id === 'data')
       : [];
-    if (!features.length) return;
+    if (!features.length) {
+      this.setState({ popupInfo: null });
+      return;
+    }
     // If there are still several features, pick one at random
     // Future: might be better to calculate which is closest to cursor
     const index = Math.floor(Math.random() * features.length);
@@ -93,6 +96,7 @@ class Map extends React.PureComponent {
   }
 
   handleHover(event) {
+    if (!event.features) return;
     const isHoveringFeature = event.features.some(
       feature => feature.layer.id === 'data',
     );

--- a/app/components/Map/index.js
+++ b/app/components/Map/index.js
@@ -14,6 +14,8 @@ import { townArray } from './townConstants';
 import CityInfo from './cityInfo';
 import Wrapper from './Wrapper';
 
+const clickRadius = navigator.userAgent.includes('Mobi') ? 10 : 0;
+
 /* eslint-disable react/prefer-stateless-function */
 class Map extends React.PureComponent {
   constructor(props) {
@@ -95,6 +97,17 @@ class Map extends React.PureComponent {
     this.setState({ popupInfo: features[index].properties });
   }
 
+  handleHover(event) {
+    const isHoveringFeature = event.features.some(
+      feature => feature.layer.id === 'data',
+    );
+    if (isHoveringFeature) {
+      event.target.style.cursor = 'pointer'; // eslint-disable-line
+    } else {
+      event.target.style.cursor = 'grab'; // eslint-disable-line
+    }
+  }
+
   renderPopup() {
     const { popupInfo } = this.state;
 
@@ -126,7 +139,8 @@ class Map extends React.PureComponent {
           {...this.state.viewport}
           onViewportChange={viewport => this.setState({ viewport })}
           onClick={this.handleClick}
-          clickRadius={10}
+          onHover={_.throttle(this.handleHover, 100)}
+          clickRadius={clickRadius}
           mapboxApiAccessToken="pk.eyJ1IjoiaHlwZXJmbHVpZCIsImEiOiJjaWpra3Q0MnIwMzRhdGZtNXAwMzRmNXhvIn0.tZzUmF9nGk2h28zx6PM13w"
         >
           {!!this.state.geoJSON && (


### PR DESCRIPTION
- Throttled the hover event so that it doesn't blow up slower computers
- Changed click radius for computers. Once hovering was implemented it was clear that the click radius was way too wide for precise pointers. User agent sniffing might not be a guarantee but it is probably the best option, short of waiting for a touch event and changing the click radius.
- Removed the coordinate correction hack. Roughly half of the points will appear in Antarctica until the coordinates are corrected in the database.
- Close popups when clicking outside of feature