### PR TITLE
Fix analyze script, work on reducing bundle size

### DIFF
--- a/app/containers/LocationTablePage/index.js
+++ b/app/containers/LocationTablePage/index.js
@@ -5,11 +5,13 @@
  *
  */
 
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import Grid from '@material-ui/core/Grid';
+import CircularProgress from '@material-ui/core/CircularProgress';
 import { FormattedMessage } from 'react-intl';
-import LocationTable from '../../components/LocationTable';
+
 import messages from './messages';
+const LocationTable = lazy(() => import('../../components/LocationTable'));
 
 export default function LocationTablePage() {
   return (
@@ -22,7 +24,9 @@ export default function LocationTablePage() {
       <h1 className="headline">
         <FormattedMessage {...messages.header} />
       </h1>
-      <LocationTable />
+      <Suspense fallback={<CircularProgress />}>
+        <LocationTable />
+      </Suspense>
     </Grid>
   );
 }

--- a/internals/scripts/analyze.js
+++ b/internals/scripts/analyze.js
@@ -9,7 +9,7 @@ const progress = animateProgress('Generating stats');
 
 // Generate stats.json file with webpack
 shelljs.exec(
-  'webpack --config internals/webpack/webpack.prod.babel.js --profile --json > stats.json',
+  'cross-env NODE_ENV=production webpack --config internals/webpack/webpack.prod.babel.js --json > stats.json',
   addCheckMark.bind(null, callback), // Output a checkmark on completion
 );
 


### PR DESCRIPTION
See related issue https://github.com/CodeForPittsburgh/food-access-map/issues/43

This PR fixes an issue with the `analyze` script incorrectly analyzing the bundle, and lazy loads `LocationTable` to help reduce the initial load transferred to the client